### PR TITLE
[recode] Account for spilled values of one/two bytes

### DIFF
--- a/criu-3.15/lib/py/st_reg_transform.py
+++ b/criu-3.15/lib/py/st_reg_transform.py
@@ -271,7 +271,11 @@ def _get_val(ctx, val, arch=False, return_loc = False):
                         raw_val.append(struct.unpack(
                             '<Q', ctx.pages.read(8))[0])
             else:
-                if val.size == 4:
+                if val.size == 1:
+                    raw_val = struct.unpack('<B', ctx.pages.read(1))[0]
+                elif val.size == 2:
+                    raw_val = struct.unpack('<H', ctx.pages.read(2))[0]
+                elif val.size == 4:
                     raw_val = struct.unpack('<I', ctx.pages.read(4))[0]
                 elif val.size == 8:
                     raw_val = struct.unpack('<Q', ctx.pages.read(8))[0]
@@ -403,7 +407,11 @@ def _put_val(dest_ctx, dest_val, raw_val, arch=False, return_loc = False, fixup_
                     for i in range(write_count):
                         write_val.append(struct.pack("Q", raw_val[i]))
             else:
-                if dest_val.size == 4:
+                if dest_val.size == 1:
+                    write_val.append(struct.pack("I", raw_val))
+                elif dest_val.size == 2:
+                    write_val.append(struct.pack("I", raw_val))
+                elif dest_val.size == 4:
                     write_val.append(struct.pack("I", raw_val))
                 elif dest_val.size == 8:
                     write_val.append(struct.pack("Q", raw_val))


### PR DESCRIPTION
In X86, an architecture-specific value can be of size 1 byte. If this is spilled, it is recorded as a live value of size 1. During `recode` this needs to be handled, as we did previously for the case of 4 bytes. The difference is that we recode it as a value of 4 bytes, since AArch64 only handles 4 bytes and above. So, if we encoded it as 1 byte, we probably would run into issues due to AArch64 reading more than 1 byte from memory.

Regarding correctness, since both architectures have the same number of live values, this expansion should not affect correctness, e.g., by overwriting other live values, but we need to test this more. Finally, we also add the case of byte size of 2 for completeness.