### PR TITLE
[trace] Use mask properly when removing the trap

### DIFF
--- a/tools/tracer.c
+++ b/tools/tracer.c
@@ -341,7 +341,7 @@ void remove_trap(pid_t pid, long addr)
     long d;
     d = ptrace(PTRACE_PEEKTEXT, pid, (void *)addr, NULL);
 #ifdef __x86_64__
-    long data = (d & 0xFFFFFF00) | 0x90;
+    long data = (d & 0xFFFFFFFFFFFFFF00) | 0x90;
 #endif
 #ifdef __aarch64__
     long data = (d & 0xFFFFFFFF00000000) | 0xe1a00000;


### PR DESCRIPTION
The problem is this operation in `remove_trap`:
```cpp
    long data = (d & 0xFFFFFF00) | 0x90;
```
which attempts to replace the breakpoint (the last two bytes: `0xcc`), with a NOP (`0x90`).

The issue is that this zeroes out the high bits of `d`, after the 4th byte. This wasn't causing an issue so far when this was used in`check_migrate`, because these bits were zero anyway:
```asm
  50278f:       cc                      int3
  502790:       5d                      pop    rbp
  502791:       c3                      ret
```
because they are the padding after the function.

But, if we modify `check_migrate`, then it zeroes out other useful instructions after the 4th byte, e.g., in a modified version there is an additional `add` instruction to restore the stack pointer:
```asm
  5027a4:       cc                      int3
  5027a5:       48 83 c4 10             add    rsp,0x10
  5027a9:       5d                      pop    rbp
  5027aa:       c3                      ret
```

Why doesn't this happen with `set_breakpoint`?
```cpp
    long data = ptrace(PTRACE_PEEKTEXT, pid, (void *)addr, 0);

    long trap = (data & 0xFFFFFF00) | 0xCC;
```

Because the data is saved and returned as is, without being zeroed out. And in `trap`, we anyway use just the first instruction (breakpoint: `0xCC`), which pauses us and doesn't continue to an invalid instruction.