### PR TITLE
[recode] Implement recode without stack transformation

### DIFF
--- a/criu-3.15/lib/py/cli.py
+++ b/criu-3.15/lib/py/cli.py
@@ -541,10 +541,10 @@ def recode(opts):
         debug = True
     if opts['target'] == "aarch64":
         converter = Aarch64Converter(opts['src_dir'], opts['dest_dir'], 
-            opts['src_bin'], opts['bin_dir'], debug)
+            opts['src_bin'], opts['bin_dir'], debug, opts['no_transform'])
     elif opts['target'] == 'x86-64':
         converter = X8664Converter(opts['src_dir'], opts['dest_dir'], 
-            opts['src_bin'], opts['bin_dir'], debug)
+            opts['src_bin'], opts['bin_dir'], debug, opts['no_transform'])
     else:
         raise Exception('Architecture not supported')
     converter.assert_conditions()
@@ -812,6 +812,8 @@ def main():
     recode_parser.add_argument('src_bin', help='source binary file name')
     recode_parser.add_argument('bin_dir', help='bin directory')
     recode_parser.add_argument('debug', help='run in debug mode(y/n)')
+    recode_parser.add_argument('--no-transform', action='store_true',
+        help='disable stack transformation')
     recode_parser.set_defaults(func=recode)
     
     # Examine

--- a/criu-3.15/lib/py/converter.py
+++ b/criu-3.15/lib/py/converter.py
@@ -91,7 +91,7 @@ PAGESIZE = 4096
 class Converter():  # TODO: Extend the logic for multiple PIDs
     __metaclass__ = ABCMeta
 
-    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug):
+    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform=False):
         assert os.path.exists(src_dir), "Source directory does not exist"
         assert os.path.exists(
             join(src_dir, src_bin)), "Source binary does not exist"
@@ -101,6 +101,7 @@ class Converter():  # TODO: Extend the logic for multiple PIDs
                               ), "Binary aarch64 copy does not exist"
         self.arch = None
         self.debug = debug
+        self.transform_needed = not no_transform
         self.images = {}
         self.src_dir = src_dir
         self.dest_dir = dest_dir
@@ -654,13 +655,16 @@ class Converter():  # TODO: Extend the logic for multiple PIDs
             self.rewrite_context_init(src_handle, src_regset, dest_handle, dest_regset)
             assert self.dest_rewrite_ctx, 'dest rewrite context not initialized'
             assert self.src_rewrite_ctx, 'src rewrite context not initialized'
-            unwind_and_size(self.src_rewrite_ctx, self.dest_rewrite_ctx)
+            unwind_and_size(self.src_rewrite_ctx, self.dest_rewrite_ctx, self.transform_needed)
             assert len(self.src_rewrite_ctx.activations) == \
                 len(self.dest_rewrite_ctx.activations), "act count unequal for src and dest"
-            for j in range(len(self.dest_rewrite_ctx.activations)):
-                self.src_rewrite_ctx.act = j
-                self.dest_rewrite_ctx.act = j
-                rewrite_frame(self.src_rewrite_ctx, self.dest_rewrite_ctx)
+            if self.transform_needed:
+                for j in range(len(self.dest_rewrite_ctx.activations)):
+                    self.src_rewrite_ctx.act = j
+                    self.dest_rewrite_ctx.act = j
+                    rewrite_frame(self.src_rewrite_ctx, self.dest_rewrite_ctx)
+            else:
+                self.log('Common stack layout: no stack transformation')
             self.dest_rewrite_ctx.pages.close()
             self.dest_rewrite_ctx.regset = self.dest_rewrite_ctx.activations[0].regset
             self.dest_rewrite_ctx.regset.copy_out(dest_core['entries'][0])
@@ -705,8 +709,8 @@ class Converter():  # TODO: Extend the logic for multiple PIDs
 
 #aarch64 to x86-64
 class X8664Converter(Converter):
-    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug):
-        Converter.__init__(self, src_dir, dest_dir, src_bin, bin_dir, debug)
+    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform=False):
+        Converter.__init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform)
         self.arch = X8664
     
     def assert_conditions(self):  # call before calling recode
@@ -906,8 +910,8 @@ class X8664Converter(Converter):
 
 #x86-64 to aarch64
 class Aarch64Converter(Converter):
-    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug):
-        Converter.__init__(self, src_dir, dest_dir, src_bin, bin_dir, debug)
+    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform=False):
+        Converter.__init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform)
         self.arch = AARCH64
 
     def assert_conditions(self):  # call before calling recode

--- a/criu-3.15/lib/py/regops.py
+++ b/criu-3.15/lib/py/regops.py
@@ -13,6 +13,12 @@ def _x86_sp(regset):
 def _x86_bp(regset):
     return regset.rbp
 
+def _x86_csr1(regset):
+    return regset.rbx
+
+def _x86_csr2(regset):
+    return regset.r15
+
 def _x86_pc(regset):
     return regset.rip
 
@@ -24,6 +30,12 @@ def _x86_set_bp(bp, regset):
 
 def _x86_set_pc(pc, regset):
     regset.rip = pc
+
+def _x86_set_csr1(rbx, regset):
+    regset.rbx = rbx
+
+def _x86_set_csr2(r15, regset):
+    regset.r15 = r15
 
 def _x86_get_reg_val(regnum, regset):
     if regnum == reg_x86_64.RAX:
@@ -177,6 +189,12 @@ def _aarch_pc(regset):
 def _aarch_bp(regset):
     return regset.x[29]
 
+def _aarch_csr1(regset):
+    return regset.x[19]
+
+def _aarch_csr2(regset):
+    return regset.x[20]
+
 def _aarch_set_sp(sp, regset):
     regset.sp = sp
 
@@ -186,6 +204,12 @@ def _aarch_set_pc(pc, regset):
 
 def _aarch_set_bp(bp, regset):
     regset.x[29] = bp
+
+def _aarch_set_csr1(x19, regset):
+    regset.x[19] = x19
+
+def _aarch_set_csr2(x20, regset):
+    regset.x[20] = x20
 
 def _aarch64_get_reg_val(regnum, regset):
     if regnum <= 30:
@@ -214,9 +238,13 @@ x86 = {
     'sp' : _x86_sp,
     'bp' : _x86_bp,
     'pc' : _x86_pc,
+    'csr1' : _x86_csr1,
+    'csr2' : _x86_csr2,
     'set_sp' : _x86_set_sp,
     'set_bp' : _x86_set_bp,
     'set_pc' : _x86_set_pc,
+    'set_csr1' : _x86_set_csr1,
+    'set_csr2' : _x86_set_csr2,
     'reg_val' : _x86_get_reg_val,
     'set_reg' : _x86_set_reg_val,
     'bp_regnum' : _x86_bp_regnum
@@ -226,9 +254,13 @@ aarch = {
     'sp' : _aarch_sp,
     'bp' : _aarch_bp,
     'pc' : _aarch_pc,
+    'csr1' : _aarch_csr1,
+    'csr2' : _aarch_csr2,
     'set_sp' : _aarch_set_sp,
     'set_bp' : _aarch_set_bp,
     'set_pc' : _aarch_set_pc,
+    'set_csr1' : _aarch_set_csr1,
+    'set_csr2' : _aarch_set_csr2,
     'reg_val' : _aarch64_get_reg_val,
     'set_reg' : _aarch64_set_reg_val,
     'bp_regnum' : _aarch64_bp_regnum

--- a/criu-3.15/lib/py/st_reg_transform.py
+++ b/criu-3.15/lib/py/st_reg_transform.py
@@ -10,7 +10,27 @@ from . import definitions
 from . import reg_aarch64
 from . import reg_x86_64
 
-def unwind_and_size(src_rewrite_ctx, dest_rewrite_ctx):
+
+def unwind_and_size(src_rewrite_ctx, dest_rewrite_ctx, transform_needed=True):
+    """
+    Walk the source activation records from the innermost to the outermost and create the destination
+    activation records and get the destination stack size.
+
+    In the loop the dependencies are:
+        * pc -> callsite -> frame size -> sp'
+        * sp/bp -> regset -> frame pop -> bp'/pc'
+    where the accent (`'`) denotes the next outer activation.
+
+    If `transform_needed` is false, it means that there will not be stack transformation (like in the case of Unifico),
+    so we need to copy the source activations verbatim to the destination memory, but when we return from this
+    function we will not perform any transformation on the activations. Also, we need to copy out the innermost
+    activation's callee-saved registers to the respective destination activation.
+
+    :param src_rewrite_ctx:
+    :param dest_rewrite_ctx:
+    :param transform_needed:
+    :return:
+    """
     src_handle = src_rewrite_ctx.st_handle
     dest_handle = dest_rewrite_ctx.st_handle
     dest_stack_size = 0
@@ -40,6 +60,9 @@ def unwind_and_size(src_rewrite_ctx, dest_rewrite_ctx):
             dest_bp += dest_cs.frame_size - src_cs.frame_size
         if act == 0:
             src_act_regset.deep_copy(src_rewrite_ctx.regset)
+            if not transform_needed:
+                # No transformation will be needed, so copy out the innermost activation callee-saved registers.
+                _remap_callee_saved(src_handle, src_act_regset, dest_handle, dest_act_regset)
         src_handle.regops['set_sp'](act_sp, src_act_regset)
         src_handle.regops['set_bp'](src_bp, src_act_regset)
         dest_handle.regops['set_sp'](dest_sp, dest_act_regset)
@@ -62,7 +85,14 @@ def unwind_and_size(src_rewrite_ctx, dest_rewrite_ctx):
             break
     dest_rewrite_ctx.stack_size = dest_stack_size
     dest_rewrite_ctx.pages.seek(dest_rewrite_ctx.stack_top_offset)
-    dest_rewrite_ctx.pages.write(b'\x00' * dest_stack_size)
+    if transform_needed:
+        # Clear and set up the destination memory for the activations
+        dest_rewrite_ctx.pages.write(b'\x00' * dest_stack_size)
+    else:
+        # No transformation will be needed, so just copy verbatim the activations
+        src_rewrite_ctx.pages.seek(src_rewrite_ctx.stack_top_offset)
+        common_stack = src_rewrite_ctx.pages.read(dest_stack_size)
+        dest_rewrite_ctx.pages.write(common_stack)
 
 def _first_frame(call_site):
     return call_site.id == definitions.UINT64_MAX
@@ -462,3 +492,28 @@ def _points_to_stack(ctx, live_val):
             (stack_addr - sp + ctx.stack_top_offset) >= ctx.stack_base_offset:
         stack_addr = None
     return stack_addr
+
+
+def _remap_callee_saved(src_handle, src_act_regset, dest_handle, dest_act_regset):
+    """
+    Do a remapping from the source callee-saved registers to the destination.
+
+    This is in needed in cases like Unifico, where we don't want to do a stack transformation so,
+    in terms of registers, we only need to copy out the innermost activation's callee-saved registers
+    from source to destination. Currently, we assume that migration only happens at function boundaries,
+    so the only live values that won't be in the stack are the CSRs of the innermost frame. Other registers,
+    may have been clobbered after returning from the call, so there is no need to copy them out.
+
+    This function is called only from the innermost activation (activation 0). Currently, we assume only two
+    CSRs, based on the Unifico mapping. Other special registers like the base pointer or the instruction pointer
+    are handled separately in `unwind_and_size`.
+    :param src_handle:
+    :param src_act_regset:
+    :param dest_handle:
+    :param dest_act_regset:
+    :return:
+    """
+    csr1 = src_handle.regops['csr1'](src_act_regset)
+    csr2 = src_handle.regops['csr2'](src_act_regset)
+    dest_handle.regops['set_csr1'](csr1, dest_act_regset)
+    dest_handle.regops['set_csr2'](csr2, dest_act_regset)

--- a/experiments/common.mk
+++ b/experiments/common.mk
@@ -36,12 +36,18 @@ OBJDUMP := objdump $(OBJDUMP_FLAGS)
 TRACER := $(TRANSPROC)/tools/tracer
 CRIU := $(TRANSPROC)/criu-3.15/criu/criu -vvv --shell-job
 CRIT := $(TRANSPROC)/criu-3.15/crit/crit
+CRIT_RECODE := $(CRIT) recode
 SERVER_TO_QEMU := $(TRANSPROC)/tools/server_to_qemu.py --password-file $(TRANSPROC)/tools/pass.txt
 
 ## Hyperfine configs
 WARMUP ?= 5
 RUNS ?= 1
 HYPERFINE := hyperfine --warmup $(WARMUP) --runs $(RUNS) --show-output
+
+## crit configs
+ifdef NOTRANSFORM
+  CRIT_RECODE += --no-transform
+endif
 
 all:
 	make -C criu-3.15 -j$(shell nproc)
@@ -62,10 +68,10 @@ dump:
 	sudo $(CRIU) dump -o dump.log -t $(shell pidof $(BIN))
 
 recode-x86:
-	$(RUN_PREPEND) $(PYTHON) $(CRIT) recode $(CURDIR) $(CURDIR)/$(ARM_TARGET) $(ARM_TARGET) $(BIN) $(BINDIR) $(DEBUG)
+	$(RUN_PREPEND) $(PYTHON) $(CRIT_RECODE) $(CURDIR) $(CURDIR)/$(ARM_TARGET) $(ARM_TARGET) $(BIN) $(BINDIR) $(DEBUG)
 
 recode-arm:
-	$(RUN_PREPEND) $(PYTHON) $(CRIT) recode $(CURDIR) $(CURDIR)/$(X86_TARGET) $(X86_TARGET) $(BIN) $(BINDIR) $(DEBUG)
+	$(RUN_PREPEND) $(PYTHON) $(CRIT_RECODE) $(CURDIR) $(CURDIR)/$(X86_TARGET) $(X86_TARGET) $(BIN) $(BINDIR) $(DEBUG)
 
 restore:
 	sudo $(RUN_PREPEND) $(CRIU) restore -o restore.log
@@ -147,10 +153,10 @@ perf-spawn:
 	$(HYPERFINE) '$(RUN_PREPEND) $(CURDIR)/$(BIN)'
 
 perf-recode-x86:
-	$(HYPERFINE) '$(RUN_PREPEND) $(PYTHON) $(CRIT) recode $(CURDIR) $(CURDIR)/$(ARM_TARGET) $(ARM_TARGET) $(BIN) $(BINDIR) $(DEBUG)'
+	$(HYPERFINE) '$(RUN_PREPEND) $(PYTHON) $(CRIT_RECODE) $(CURDIR) $(CURDIR)/$(ARM_TARGET) $(ARM_TARGET) $(BIN) $(BINDIR) $(DEBUG)'
 
 perf-recode-arm:
-	$(HYPERFINE) '$(RUN_PREPEND) $(PYTHON) $(CRIT) recode $(CURDIR) $(CURDIR)/$(X86_TARGET) $(X86_TARGET) $(BIN) $(BINDIR) $(DEBUG)'
+	$(HYPERFINE) '$(RUN_PREPEND) $(PYTHON) $(CRIT_RECODE) $(CURDIR) $(CURDIR)/$(X86_TARGET) $(X86_TARGET) $(BIN) $(BINDIR) $(DEBUG)'
 
 ### Runs the hyperfine command using `setsid` and `script` to simulate a terminal
 ### environment, which is required for CRIU restore, since hyperfine runs in


### PR DESCRIPTION
With stack transformation disabled, what recode will essentially do in terms of stack and registers will be to:
1. Copy the source activations verbatim to the destination memory, without performing any transformation on the activations.
2. Copy out the innermost activation's callee-saved registers from source to destination.

Currently, we assume that migration only happens at function boundaries, so the only live values that won't be in the stack are the CSRs of the innermost frame. Other registers, may have been clobbered after returning from the call, so there is no need to copy them out.

Finally, adds option to disable stack transformation.  Activate (=disable) with --no-transform, when using `crit`. To use from the experiments makefile, define the NOTRANSFORM variable.