### PR TITLE
[recode] Add option to completely skip transformation of core/memory/…

### DIFF
--- a/criu-3.15/lib/py/cli.py
+++ b/criu-3.15/lib/py/cli.py
@@ -541,10 +541,10 @@ def recode(opts):
         debug = True
     if opts['target'] == "aarch64":
         converter = Aarch64Converter(opts['src_dir'], opts['dest_dir'], 
-            opts['src_bin'], opts['bin_dir'], debug, opts['no_transform'])
+            opts['src_bin'], opts['bin_dir'], debug, opts['no_transform'], opts['measure_transform'])
     elif opts['target'] == 'x86-64':
         converter = X8664Converter(opts['src_dir'], opts['dest_dir'], 
-            opts['src_bin'], opts['bin_dir'], debug, opts['no_transform'])
+            opts['src_bin'], opts['bin_dir'], debug, opts['no_transform'], opts['measure_transform'])
     else:
         raise Exception('Architecture not supported')
     converter.assert_conditions()
@@ -814,6 +814,9 @@ def main():
     recode_parser.add_argument('debug', help='run in debug mode(y/n)')
     recode_parser.add_argument('--no-transform', action='store_true',
         help='disable stack transformation')
+    recode_parser.add_argument('--measure-transform', action='store_true',
+                               help='disable transformation of memory pages, stack, and registers, as a form of '
+                                    'ablation study to estimate the impact of transformation on the application state')
     recode_parser.set_defaults(func=recode)
     
     # Examine

--- a/criu-3.15/lib/py/converter.py
+++ b/criu-3.15/lib/py/converter.py
@@ -91,7 +91,7 @@ PAGESIZE = 4096
 class Converter():  # TODO: Extend the logic for multiple PIDs
     __metaclass__ = ABCMeta
 
-    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform=False):
+    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform=False, measure_transform=False):
         assert os.path.exists(src_dir), "Source directory does not exist"
         assert os.path.exists(
             join(src_dir, src_bin)), "Source binary does not exist"
@@ -102,6 +102,7 @@ class Converter():  # TODO: Extend the logic for multiple PIDs
         self.arch = None
         self.debug = debug
         self.transform_needed = not no_transform
+        self.measure_transform = measure_transform
         self.images = {}
         self.src_dir = src_dir
         self.dest_dir = dest_dir
@@ -699,18 +700,20 @@ class Converter():  # TODO: Extend the logic for multiple PIDs
         self.transform_inventory_file()
         self.transform_pstree_file()
         self.transform_ttyinfo_file()
-        self.transform_target_mem()
-        self.transform_core_file()
+        if not self.measure_transform:
+            self.transform_target_mem()
+            self.transform_core_file()
         self.transform_files_file()
         self.transform_ids_file()
-        self.transform_stack_and_regs()
+        if not self.measure_transform:
+            self.transform_stack_and_regs()
         self.transform_seccomp_file()
         self.transform_timens_file()
 
 #aarch64 to x86-64
 class X8664Converter(Converter):
-    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform=False):
-        Converter.__init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform)
+    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform=False, measure_transform=False):
+        Converter.__init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform, measure_transform)
         self.arch = X8664
     
     def assert_conditions(self):  # call before calling recode
@@ -910,8 +913,8 @@ class X8664Converter(Converter):
 
 #x86-64 to aarch64
 class Aarch64Converter(Converter):
-    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform=False):
-        Converter.__init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform)
+    def __init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform=False, measure_transform=False):
+        Converter.__init__(self, src_dir, dest_dir, src_bin, bin_dir, debug, no_transform, measure_transform)
         self.arch = AARCH64
 
     def assert_conditions(self):  # call before calling recode

--- a/experiments/common.mk
+++ b/experiments/common.mk
@@ -48,6 +48,10 @@ HYPERFINE := hyperfine --warmup $(WARMUP) --runs $(RUNS) --show-output
 ifdef NOTRANSFORM
   CRIT_RECODE += --no-transform
 endif
+ifdef MEASURE_TRANSFORM
+  CRIT_RECODE += --measure-transform
+endif
+
 
 all:
 	make -C criu-3.15 -j$(shell nproc)


### PR DESCRIPTION
…stack/registers

This allows us to perform ablation studies on recode to estimate what is the impact of any kind of transformation on the application state, by only performing OS state transformations. We want to use this as a proxy for a fair comparison between Unifico and Popcorn, so that we keep the OS state transformation for both binaries, but measure what would be the performance improvement if we didn't have to transform anything related to the application state with Unifico.

Activate with `--measure-transform` when running `crit`, or with `MEASURE_TRANFORM` when using the top-level experiments Makefile.