### PR TITLE
[tracer] Do not reset the pc for AArch64 after trap

### DIFF
--- a/tools/tracer.c
+++ b/tools/tracer.c
@@ -463,7 +463,6 @@ void *trace_thread(void *argp)
     log_info("Thread %d: x[30] = 0x%08llx", thread_id, regs.regs[30]);
     ret_addr = regs.regs[30];
     brk_addr = regs.pc;
-    regs.pc -= 4;
 #endif
 
     /* main thread only. Remove compiler placed trap, restore indicator val*/


### PR DESCRIPTION
In X86, it seems that the program counter is advanced after the trap:

```asm
0000000000502840 <check_migrate>:
  502840:       55                      push   rbp
...
  50286e:       e9 63 00 00 00          jmp    5028d6 <check_migrate+0x96>
  502873:       cc                      int3
  502874:       c7 04 25 60 34 00 11    mov    DWORD PTR ds:0x11003460,0x0
```

Tracer output:
```yaml
INFO  Thread 460772 got signal Trace/breakpoint trap   at trace_thread (tracer.c:440)
INFO  Thread 460772: RIP = 0x00502874   at trace_thread (tracer.c:465) # <===
INFO  Thread 460772: RBP = 0x7ffd38cf4ad0   at trace_thread (tracer.c:466)
INFO  Thread 460772: Value at BP+0x8: 0x00501580   at trace_thread (tracer.c:471)
```

so, we need to reset it with this piece of code:
```cpp
    /* Get the migration point info */
    log_info("Thread %d: RIP = 0x%08llx", thread_id, regs.rip);
    log_info("Thread %d: RBP = 0x%08llx", thread_id, regs.rbp);
    ret_add_loc = regs.rbp + 8;
    regs.rip -= 1; // <===
    brk_addr = regs.rip;
    ret_addr = ptrace(PTRACE_PEEKDATA, thread_id, (void *)ret_add_loc, NULL);
    log_info("Thread %d: Value at BP+0x8: 0x%08lx", thread_id, ret_addr);
```

but in AArch64 it doesn't:

```asm
0000000000502840 <check_migrate>:
  502840:       d100c3ff        sub     sp, sp, #0x30
...
  502874:       1400001b        b       5028e0 <check_migrate+0xa0>
  502878:       d4200000        brk     #0x0
  50287c:       b0085808        adrp    x8, 11003000 <randlc.KS>
```

Tracer output:
```yaml
INFO  Thread 460772 got signal Trace/breakpoint trap   at trace_thread (tracer.c:440)
INFO  Thread 460772: PC = 0x00502878   at trace_thread (tracer.c:474)
INFO  Thread 460772: x[30] = 0x00501580   at trace_thread (tracer.c:475)
INFO  Thread 460772: addr: 0x00502878 opcode 0xb0085808d4200000   at trace_thread (tracer.c:485)
```

so, we shouldn't be resetting the pc:

```cpp
    log_info("Thread %d: PC = 0x%08llx", thread_id, regs.pc);
    log_info("Thread %d: x[30] = 0x%08llx", thread_id, regs.regs[30]);
    ret_addr = regs.regs[30];
    brk_addr = regs.pc;
    regs.pc -= 4; // <===
```