### PR TITLE
[recode] Fix how the FP control register is recoded to x86

### DIFF
--- a/criu-3.15/lib/py/converter.py
+++ b/criu-3.15/lib/py/converter.py
@@ -835,7 +835,7 @@ class X8664Converter(Converter):
             # fpregs
             self.log("WARNING: floating point registers not fully supported")
             dst_info["fpregs"]= {
-                "cwd": 0, "swd": 0, "twd": 0, "fop": 0,
+                "cwd": 0x037f, "swd": 0, "twd": 0, "fop": 0,
                 "rip": 0, "rdp": 0, "mxcsr": 8064, "mxcsr_mask": 65535,
                 "st_space": [ 0, 0, 0, 0, 0, 0, 0, 0,
                             0, 0, 0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
When recoding from arm to x86, it seems that we have to set `cwd` to a reasonable default. The definition of `cwd` be found in: https://elixir.bootlin.com/linux/v5.4.205/source/arch/x86/include/asm/fpu/types.h

Otherwise, when moving back to x86, `c_print_results` gives a SIGFPE error. It seems that the value `0x037f` (round-to-nearest, 64-bit precision, all exceptions masked), gives a reasonable default.