### PR TITLE
Add multitrip rules

### DIFF
--- a/experiments/common.mk
+++ b/experiments/common.mk
@@ -1,4 +1,4 @@
-.PHONY: all vdso clean get-from-x86 get-from-arm clean-img
+.PHONY: all vdso clean get-from-x86 get-from-arm clean-img trip trip-x86-init trip-x86-continue trip-arm
 
 BIN ?= loop
 # Folder inside the TransProc repo
@@ -162,11 +162,42 @@ perf-recode-x86:
 perf-recode-arm:
 	$(HYPERFINE) '$(RUN_PREPEND) $(PYTHON) $(CRIT_RECODE) $(CURDIR) $(CURDIR)/$(X86_TARGET) $(X86_TARGET) $(BIN) $(BINDIR) $(DEBUG)'
 
-### Runs the hyperfine command using `setsid` and `script` to simulate a terminal
-### environment, which is required for CRIU restore, since hyperfine runs in
-### non-interactive mode.
+trip-x86-init:
+	# Go to the x86 QEMU instance and restore, run until a migration point, dump, and recode.
+	# Uses the `-t` option to create a new TTY for the SSH session.
+	ssh -t ubuntu@127.0.0.1 -p 5555 'cd $(QEMU_TRANSPROC_X86)/$(LOCATION); make clean; ./$(BIN) & ; make trace; make dump; make recode-x86 $(NOTRANSFORM)'
+
+trip-x86-continue:
+	# Go to the x86 QEMU instance and restore, run until a migration point, dump, and recode, so that a new cycle can continue.
+	ssh $(QEMU_USER_X86)@$(QEMU_IP_X86) -p $(QEMU_PORT_X86) 'cd $(QEMU_TRANSPROC_X86)/$(LOCATION); make safe-restore &; sleep 1; sudo kill -CONT $$(pidof $(BIN)); make trace; make dump; make recode-x86 $(NOTRANSFORM)'
+
+trip-x86-finalize:
+	# Go to the x86 QEMU instance and restore.
+	ssh $(QEMU_USER_X86)@$(QEMU_IP_X86) -p $(QEMU_PORT_X86) 'cd $(QEMU_TRANSPROC_X86)/$(LOCATION); make safe-restore &; sleep 1; sudo kill -CONT $$(pidof $(BIN))'
+
+trip-arm: clean copy-to-qemu-arm
+	# Go to the arm QEMU instance and restore, run until a migration point, dump, and recode.
+	$(PYTHON) $(SERVER_TO_QEMU) $(SERVER_ARM) $(QEMU_PORT_ARM) $(QEMU_TRANSPROC_ARM)/$(LOCATION) $(BIN) \
+		--command "cd $(QEMU_TRANSPROC_X86)/$(LOCATION); make safe-restore & ; sleep 0.5; make trace; make dump; make recode-arm $(NOTRANSFORM)"
+	# Get the recoded arm->x86 images
+	$(PYTHON) $(SERVER_TO_QEMU) $(SERVER_ARM) $(QEMU_PORT_ARM) $(QEMU_TRANSPROC_ARM)/$(LOCATION)/$(X86_TARGET) $(X86_TARGET) --download
+	# Clean up the previous images from the x86 QEMU instance
+	ssh -p $(QEMU_PORT_X86) $(QEMU_USER_X86)@$(QEMU_IP_X86) "$(RM) $(QEMU_TRANSPROC_X86)/$(LOCATION)/*.img"
+	# Transfer the new images to the x86 QEMU instance
+	scp -P $(QEMU_PORT_X86) -r $(X86_TARGET)/* $(QEMU_USER_X86)@$(QEMU_IP_X86):$(QEMU_TRANSPROC_X86)/$(LOCATION)/
+
+perf-trip-arm:
+	ssh ubuntu@127.0.0.1 -p 5556 "cd ~/TransProc/experiments/is.popcorn.O0.A; make safe-restore & ; sleep 0.5; make trace; make dump; make recode-arm"
+
+### The following use `setsid` and `script` to simulate a terminal,
+### which is required for CRIU restore, since hyperfine runs in non-interactive mode.
 perf-restore:
 	$(HYPERFINE) 'setsid script -q -c "sudo $(RUN_PREPEND) $(CRIU) restore -o restore.log" /dev/null'
+
+### Similarly, with above, the following use `setsid` and `script` to simulate a terminal,
+### which is required for CRIU restore later, because we will run it on the background (&).
+safe-restore:
+	setsid script -q -c "sudo $(RUN_PREPEND) $(CRIU) restore -o restore.log" /dev/null
 
 ## Clean targets
 

--- a/tools/server_to_qemu.py
+++ b/tools/server_to_qemu.py
@@ -1,6 +1,7 @@
 import paramiko
 import os
 import argparse
+import stat
 
 FIRST_SERVER_USER = "nikos"
 SECOND_SERVER = "127.0.0.1"
@@ -17,8 +18,10 @@ class TransportWrapper:
     A wrapper around a paramiko.Transport object to handle SSH connections from a local server, to a remote server, using an intermediate server as a jump host.
     """
 
-    def __init__(self, first_server, second_server_port, password):
+    def __init__(self, first_server, second_server_port, password, download=False):
         log("Initializing...")
+        self.download = download
+
         # Connect to the first server
         ssh1 = paramiko.SSHClient()
         ssh1.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -55,8 +58,14 @@ class TransportWrapper:
             log(
                 f"Running with remote path: {remote_file_path} and local path: {local_file_path}"
             )
+            if self.download:
+                # Download the directory from the remote server
+                sftp_download_dir(self.sftp, remote_file_path, local_file_path)
+                log(
+                    f"Directory {remote_file_path} downloaded successfully to {local_file_path}"
+                )
             # Perform the recursive upload
-            if os.path.isfile(local_file_path):
+            elif os.path.isfile(local_file_path):
                 # If it's a file, upload it directly
                 sftp_upload_file(self.sftp, local_file_path, remote_file_path)
             elif os.path.isdir(local_file_path):
@@ -74,6 +83,12 @@ class TransportWrapper:
 
         except Exception as e:
             print(f"Transfer error: {e}")
+
+    def exec(self, command):
+        """
+        Execute a command on the second server.
+        """
+        self.executor.exec(command)
 
     def close(self):
         """Close the SFTP session and transport."""
@@ -147,6 +162,22 @@ def sftp_upload_file(sftp, local_file, remote_dir):
     log(f"Uploaded {local_file} -> {remote_file}")
 
 
+# Helper to download a directory recursively
+def sftp_download_dir(sftp, remote_dir, local_dir):
+    """Recursively download a directory from the remote server."""
+    os.makedirs(local_dir, exist_ok=True)
+
+    for entry in sftp.listdir_attr(remote_dir):
+        remote_path = remote_dir + "/" + entry.filename
+        local_path = os.path.join(local_dir, entry.filename)
+
+        if stat.S_ISDIR(entry.st_mode):
+            sftp_download_dir(sftp, remote_path, local_path)
+        else:
+            sftp.get(remote_path, local_path)
+            print(f"Downloaded {remote_path} -> {local_path}")
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Transfer directory to a nested remote server over SSH."
@@ -168,10 +199,20 @@ if __name__ == "__main__":
         "local_file_path", type=str, help="Local directory path to upload"
     )
     parser.add_argument(
+        "--download",
+        action="store_true",
+        help="Download the remote directory to the local path",
+    )
+    parser.add_argument(
         "--password-file",
         type=str,
         default="pass.txt",
         help="Path to file containing password",
+    )
+    parser.add_argument(
+        "--command",
+        type=str,
+        help="Command to be executed on the remote server",
     )
 
     args = parser.parse_args()
@@ -184,7 +225,10 @@ if __name__ == "__main__":
         exit(1)
 
     transport_wrapper = TransportWrapper(
-        args.first_server, args.second_server_port, password
+        args.first_server, args.second_server_port, password, args.download
     )
-    transport_wrapper.run(args.remote_file_path, args.local_file_path)
-    transport_wrapper.close()
+    if args.command:
+        transport_wrapper.exec(args.command)
+    else:
+        transport_wrapper.run(args.remote_file_path, args.local_file_path)
+        transport_wrapper.close()


### PR DESCRIPTION
To be executed from the host of QEMU x86. The rules can:
* start/dump/recode the application on x86 QEMU for a first trip,
* restore/dump/recode the application on arm QEMU for a follow-up trip,
* restore/dump/recode the application on x86 QEMU for a second+ trip,
* restore/dump/recode the application on x86 QEMU for a final trip

This also adds functionality to execute arbitrary commands from a local x86 to a remote arm QEMU, and also to download images from the remote arm QEMU.

Finally, adds a `safe-restore` target that can be invoked remotely over ssh, so that it restores the TTY state properly. This was also needed because we will invoke restore as a background process (`&`).